### PR TITLE
Added more realistic example config, fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ In your project's Gruntfile, add a section named `gh-pages` to the data object p
 grunt.initConfig({
   'gh-pages': {
     options: {
-      // Task-specific options go here.
+      base: 'dist'
     },
-    src: ['index.html', 'js/**/*', 'css/**/*', 'img/**/*']
+    src: ['**']
   }
 });
 ```
@@ -209,7 +209,7 @@ grunt.initConfig({
   'gh-pages': {
     options: {
       message: 'Auto-generated commit'
-    }
+    },
     src: '**/*'
   }
 });


### PR DESCRIPTION
Hey,

Great plugin! I hate pushing to gh-pages manually.

I thought it would be cool to have a more realistic example config as I doubt anyone has their source files on the same level as their Gruntfile.

I also found a syntax error using a tool I made called [mdlint](https://github.com/ChrisWren/mdlint) which lints JavaScript code blocks in markdown files.

Thanks for making this plugin!
