### PR TITLE
grunt tasks fails if no Git Remote.URL with no error

### DIFF
--- a/tasks/gh-pages.js
+++ b/tasks/gh-pages.js
@@ -33,10 +33,15 @@ function getRepo(options) {
             return Q.resolve(repo);
           } else {
             return Q.reject(new Error(
-                'Failed to get repo URL from options or current directory'));
+                'Failed to get repo URL from options or current directory.'));
           }
         })
-        .fail(Q.reject);
+        .fail(function(err) {
+          return Q.reject(new Error(
+              'Failed to get remote.' + options.remote + '.url (' +
+              'task must either be run in a git repository with a configured ' +
+              'remote or must be configured with the "repo" option).'));
+        });
   }
 }
 


### PR DESCRIPTION
In my case I didn't push yet to the remote repo.

Running the grunt Task resulted in a  
`Warning: Process failed: 1 Use --force to continue. Aborted due to warnings.`

It might be better to catch this in the getRepo and output a nice error.
