### PR TITLE
Have to create .grunt\grunt-gh-pages\gh-pages\src manually

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -1,4 +1,5 @@
 var cp = require('child_process');
+var path = require('path');
 var util = require('util');
 
 var Q = require('q');
@@ -93,7 +94,13 @@ exports.init = function init(cwd) {
  */
 exports.clone = function clone(repo, dir) {
   return fs.exists(dir).then(function(exists) {
-    return exists ? Q.resolve() : spawn(git, ['clone', repo, dir]);
+    if (exists) {
+      return Q.resolve();
+    } else {
+      return fs.makeTree(path.dirname(dir)).then(function() {
+        return spawn(git, ['clone', repo, dir]);
+      });
+    }
   });
 };
 


### PR DESCRIPTION
On my machine (Windows 8 64bit, nodejs v0.10.17, git version 1.8.3.msysgit.0), running `grunt gh-pages` failed with:

```
Running "gh-pages:src" (gh-pages) task
Cloning https://github.com/andyli/ResearchSeminar.git into .grunt\grunt-gh-pages\gh-pages\src
Warning: fatal: could not create work tree dir '.grunt\grunt-gh-pages\gh-pages\src'.: No such file or directory
 Use --force to continue.
```

If I manually create the _.grunt\grunt-gh-pages\gh-pages\src_ folder before running the task, it will success.
