### PR TITLE
Changing repo after first deploy leads to inconsistency

### DIFF
--- a/test/fixtures/different-repo/Gruntfile.js
+++ b/test/fixtures/different-repo/Gruntfile.js
@@ -9,7 +9,7 @@ module.exports = function(grunt) {
   grunt.initConfig({
     'gh-pages': {
       options: {
-        repo: './repo',
+        repo: path.resolve('./repo'),
         user: {
           name: 'My Name',
           email: 'mail@example.com'

--- a/test/fixtures/unpushed/Gruntfile.js
+++ b/test/fixtures/unpushed/Gruntfile.js
@@ -9,7 +9,7 @@ module.exports = function(grunt) {
   grunt.initConfig({
     'gh-pages': {
       options: {
-        repo: './repo',
+        repo: path.resolve('./repo'),
         push: false,
         user: {
           name: 'My Name',


### PR DESCRIPTION
Hello,

I generated a couple of times GH pages using a config. I therefore changed the `repo` option to another repository.

The cloning into `.grunt/grunt-gh-pages` indicated the proper repo URI **but** the push was still executed towards the former repo origin.

I had to delete the `.grunt` folder and re-run the `gh-pages` task to deploy to the new `repo` value.
