### PR TITLE
Doesn't work with Git 1.7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Use [Grunt](http://gruntjs.com/) to push to your `gh-pages` branch hosted on GitHub or any other branch anywhere else.
 
 ## Getting Started
-This plugin requires Grunt `~0.4.1`
+This plugin requires Grunt `~0.4.1` and Git `>=1.7.6`.
 
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [`gruntfile.js`](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
@@ -371,5 +371,8 @@ grunt.initConfig({
 });
 ```
 
+## Dependencies
+
+Note that this plugin requires Git 1.7.6 or higher (because it uses the `--exit-code` option for `git ls-remote`).  If you'd like to see this working with earlier versions of Git, please [open an issue](https://github.com/tschaub/grunt-gh-pages/issues).
 
 [![Current Status](https://secure.travis-ci.org/tschaub/grunt-gh-pages.png?branch=master)](https://travis-ci.org/tschaub/grunt-gh-pages)


### PR DESCRIPTION
Hi, thanks for making this great tool.  My Mac was running Git 1.7.3, and when I tried to run `grunt gh-pages`, I got this error:

```
Cloning git@github.com:jeremyckahn/3d-cards.git into .grunt/grunt-gh-pages/gh-pages/src
Cleaning
Fetching origin
Checking out origin/gh-pages
Warning: usage: git ls-remote [--heads] [--tags]  [-u <exec> | --upload-pack <exec>]
                     [-q|--quiet] [<repository> [<refs>...]]
 Use --force to continue.

Aborted due to warnings.
```

I have since updated Git to version 1.8.5.1, and everything is working swimmingly.  It would be helpful if the documentation listed the minimum Git version number that is required.  Do you know what it is?
