### PR TITLE
Properly update refs so reset works

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -139,15 +139,11 @@ var reset = exports.reset = function reset(remote, branch, cwd) {
 /**
  * Fetch from a remote.
  * @param {string} remote Remote alias.
- * @param {string} branch Branch name.
  * @param {string} cwd Repository directory.
  * @return {Promise} A promise.
  */
-exports.fetch = function fetch(remote, branch, cwd) {
-  return spawn(git, ['fetch', remote, branch], cwd).fail(function(err) {
-    // try again without refspec
-    return spawn(git, ['fetch', remote], cwd);
-  });
+exports.fetch = function fetch(remote, cwd) {
+  return spawn(git, ['fetch', remote], cwd);
 };
 
 

--- a/tasks/gh-pages.js
+++ b/tasks/gh-pages.js
@@ -144,7 +144,7 @@ module.exports = function(grunt) {
         })
         .then(function() {
           log('Fetching ' + options.remote);
-          return git.fetch(options.remote, options.branch, options.clone);
+          return git.fetch(options.remote, options.clone);
         })
         .then(function() {
           log('Checking out ' + options.remote + '/' +


### PR DESCRIPTION
Calling `git fetch origin master` will update the `FETCH_HEAD` but not `refs/remotes/origin/master` so the subsequent `git reset --hard origin/master` does not reset to the fetched head.  Calling `git fetch origin` (without the refspec) updates both `FETCH_HEAD` and `refs/remotes/origin/master`.  So the following hard reset does what is expected.
