### PR TITLE
fix: not logging auth part of repo url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - "0.10"
   - "0.8"
+before_install: npm i -g npm

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
     "test": "grunt test"
   },
   "dependencies": {
+    "async": "0.2.9",
+    "graceful-fs": "2.0.1",
     "q": "0.9.3",
     "q-io": "1.6.5",
-    "graceful-fs": "2.0.1",
-    "async": "0.2.9",
+    "url-safe": "^1.0.0",
     "wrench": "1.5.1"
   },
   "devDependencies": {

--- a/tasks/gh-pages.js
+++ b/tasks/gh-pages.js
@@ -1,6 +1,7 @@
 var path = require('path');
 
 var Q = require('q');
+var urlSafe = require('url-safe');
 var wrench = require('wrench');
 
 var pkg = require('../package.json');
@@ -120,7 +121,7 @@ module.exports = function(grunt) {
     getRepo(options)
         .then(function(repo) {
           repoUrl = repo;
-          log('Cloning ' + repo + ' into ' + options.clone);
+          log('Cloning ' + urlSafe(repo,'[secure]') + ' into ' + options.clone);
           return git.clone(repo, options.clone, options.branch, options);
         })
         .then(function() {


### PR DESCRIPTION
If you have a workflow where this module runs on e.g. Travis, with publicly available logs, auth info is compromised.