### PR TITLE
Update graceful-fs dependency to latest (fixes ENFILE errors)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "async": "0.2.9",
-    "graceful-fs": "2.0.1",
+    "graceful-fs": "3.0.8",
     "q": "0.9.3",
     "q-io": "1.6.5",
     "url-safe": "^1.0.0",


### PR DESCRIPTION
On OS X with a large copy process we were still getting ENFILE errors (too many open files). Updating `graceful-fs` dependency resolves the issue for us.