### PR TITLE
Downgrade to q-io@1.13.6 for vunerability fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -139,11 +139,6 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
     "assertion-error": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
@@ -452,27 +447,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "collections": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/collections/-/collections-2.0.3.tgz",
-      "integrity": "sha1-dlcSXoSkCGotx5f/LWltgZpyD7U=",
-      "requires": {
-        "mini-map": "^1.0.0",
-        "pop-arrayify": "^1.0.0",
-        "pop-clear": "^1.0.0",
-        "pop-clone": "^1.0.1",
-        "pop-compare": "^1.0.0",
-        "pop-equals": "^1.0.0",
-        "pop-has": "^1.0.0",
-        "pop-hash": "^1.0.0",
-        "pop-iterate": "^1.0.1",
-        "pop-observe": "^2.0.2",
-        "pop-swap": "^1.0.0",
-        "pop-zip": "^1.0.0",
-        "regexp-escape": "0.0.1",
-        "weak-map": "^1.0.4"
-      }
-    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -554,7 +528,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true,
       "requires": {
         "es5-ext": "^0.10.9"
       }
@@ -705,7 +678,6 @@
       "version": "0.10.46",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
       "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
-      "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.1",
@@ -716,7 +688,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -741,7 +712,6 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "~0.10.14",
@@ -754,7 +724,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "~0.10.14"
@@ -889,7 +858,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "~0.10.14"
@@ -2240,11 +2208,6 @@
       "resolved": "https://registry.npmjs.org/mimeparse/-/mimeparse-0.1.4.tgz",
       "integrity": "sha1-2vsCdSNw/SJgk64xUsJxrwGsJUo="
     },
-    "mini-map": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mini-map/-/mini-map-1.0.0.tgz",
-      "integrity": "sha1-lkHgEV2Zs9wTcRz4z9pMgZmJP04="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -2379,8 +2342,7 @@
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-      "dev": true
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nopt": {
       "version": "3.0.6",
@@ -2647,79 +2609,6 @@
       "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
       "dev": true
     },
-    "pop-arrayify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pop-arrayify/-/pop-arrayify-1.0.0.tgz",
-      "integrity": "sha1-ZVIrP+OuIb5PjosrnkRjTBWmxIE="
-    },
-    "pop-clear": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pop-clear/-/pop-clear-1.0.0.tgz",
-      "integrity": "sha1-/IFk/IX4nyiPI7k2toAeqCKuRYY="
-    },
-    "pop-clone": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pop-clone/-/pop-clone-1.0.1.tgz",
-      "integrity": "sha1-YY1GJJfpbQb5zaMVsyXMo6JjYDg=",
-      "requires": {
-        "mini-map": "^1.0.0",
-        "pop-equals": "^1.0.0"
-      }
-    },
-    "pop-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pop-compare/-/pop-compare-1.0.0.tgz",
-      "integrity": "sha1-xzLiLCfwz6uAohfUXncitc4VGCA="
-    },
-    "pop-equals": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pop-equals/-/pop-equals-1.0.0.tgz",
-      "integrity": "sha1-kEFPj9pxo3+IHR5eOi4C7ww7fgs=",
-      "requires": {
-        "mini-map": "^1.0.0"
-      }
-    },
-    "pop-has": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pop-has/-/pop-has-1.0.0.tgz",
-      "integrity": "sha1-myJrWblgq2XqsLQS3VVw3OkOZRw=",
-      "requires": {
-        "pop-equals": "^1.0.0"
-      }
-    },
-    "pop-hash": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pop-hash/-/pop-hash-1.0.1.tgz",
-      "integrity": "sha1-vNaUVL0vmd7SC1/Iork9a1+rRMw=",
-      "requires": {
-        "weak-map": "^1.0.5"
-      }
-    },
-    "pop-iterate": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pop-iterate/-/pop-iterate-1.0.1.tgz",
-      "integrity": "sha1-zqz9q0q/NT16DyqqLB/Hs/lBO6M="
-    },
-    "pop-observe": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/pop-observe/-/pop-observe-2.0.2.tgz",
-      "integrity": "sha1-WstaxvJMfG/6ssMhUbCtt0Du82M=",
-      "requires": {
-        "pop-equals": "^1.0.0",
-        "pop-has": "^1.0.0",
-        "pop-swap": "^1.0.0"
-      }
-    },
-    "pop-swap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pop-swap/-/pop-swap-1.0.0.tgz",
-      "integrity": "sha1-iLRAVT4IXQF50yJVsJ+TqrmJDGY="
-    },
-    "pop-zip": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pop-zip/-/pop-zip-1.0.0.tgz",
-      "integrity": "sha1-PcEUAHss7OdP87jOpz6xIMcNsFY="
-    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -2744,50 +2633,35 @@
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
-    "punycode": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.0.0.tgz",
-      "integrity": "sha1-zp5sbpwdtYJxdPzrEv9JOHAKG9M="
-    },
     "q": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/q/-/q-0.9.3.tgz",
       "integrity": "sha1-QE6rutDQMe01/LU/fFvAYoO050w="
     },
     "q-io": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/q-io/-/q-io-2.0.6.tgz",
-      "integrity": "sha1-8ceCdu3F0xMVOr+sXOyGqgbINwk=",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/q-io/-/q-io-1.13.6.tgz",
+      "integrity": "sha1-BFC9s54IfLiaX9SkFjfqM0fJhTg=",
       "requires": {
-        "collections": ">=2.0.1 <3.0.0",
-        "mime": ">=1.2.11 <2.0.0",
-        "mimeparse": ">=0.1.4 <0.2.0",
-        "q": ">=2.0.1 <3.0.0",
-        "qs": ">=0.6.6 <0.7.0",
-        "url2": ">=2.0.0 <3.0.0"
+        "es6-set": "^0.1.1",
+        "mime": "^1.2.11",
+        "mimeparse": "^0.1.4",
+        "q": "^1.0.1",
+        "qs": "^1.2.1",
+        "url2": "^0.0.0"
       },
       "dependencies": {
         "q": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/q/-/q-2.0.3.tgz",
-          "integrity": "sha1-dbjbAlWhpa+C9Yw/Oqoe/sfQ0TQ=",
-          "requires": {
-            "asap": "^2.0.0",
-            "pop-iterate": "^1.0.1",
-            "weak-map": "^1.0.5"
-          }
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+          "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
         }
       }
     },
     "qs": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
-      "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc="
-    },
-    "querystring": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.1.0.tgz",
-      "integrity": "sha1-y3aibNoKEKlBY/zbPhMoJ/BLexA="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
+      "integrity": "sha1-GbV/8k3CqZzh+L32r82ln472H4g="
     },
     "raw-body": {
       "version": "1.1.7",
@@ -2882,11 +2756,6 @@
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
       }
-    },
-    "regexp-escape": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/regexp-escape/-/regexp-escape-0.0.1.tgz",
-      "integrity": "sha1-PzJqBi2PdZaykUkpVQqsd+r43nU="
     },
     "repeat-element": {
       "version": "1.1.3",
@@ -3604,27 +3473,15 @@
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
-    "url": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.7.9.tgz",
-      "integrity": "sha1-GVmxqLNh/AF7WVE6fH+pgn9eTtA=",
-      "requires": {
-        "punycode": ">=1.0.0 <1.1.0",
-        "querystring": ">=0.1.0 <0.2.0"
-      }
-    },
     "url-safe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/url-safe/-/url-safe-2.0.0.tgz",
       "integrity": "sha1-3NRt5GZqdUbuQ+qQasF12qYm3p4="
     },
     "url2": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/url2/-/url2-2.0.0.tgz",
-      "integrity": "sha1-kKOjZ945y0avQWAqAWnuho30USw=",
-      "requires": {
-        "url": ">=0.7.9 <0.8.0"
-      }
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/url2/-/url2-0.0.0.tgz",
+      "integrity": "sha1-Tqq9HVw6yQ1iq0SFyZhCKGWgSxo="
     },
     "use": {
       "version": "3.1.1",
@@ -3665,11 +3522,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "weak-map": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.5.tgz",
-      "integrity": "sha1-eWkVhNmGB/UHC9O3CkDmuyLkAes="
     },
     "websocket-driver": {
       "version": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "fs-extra": "^0.30.0",
     "graceful-fs": "4.1.5",
     "q": "0.9.3",
-    "q-io": "^2.0.6",
+    "q-io": "^1.13.6",
     "url-safe": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Turns out q-io@2 is from the future.